### PR TITLE
x2 OTA update 20210213

### DIFF
--- a/x2/gapps.json
+++ b/x2/gapps.json
@@ -4,7 +4,7 @@
         "filename": "LegionOS-v3.6-x2-20210213-1142-OFFICIAL-GAPPS.zip",
         "url": "https://sourceforge.net/projects/legionrom/files/lemax2/LegionOS-v3.6-x2-20210213-1142-OFFICIAL-GAPPS.zip/download",
         "timestamp": 1613209254,
-        "md5sum": "f60529914161c0acee93ab55fdbf749a",
+        "md5sum": "acb52fbb61cdf89ae1b106d3878beedd",
         "size": 921510651,
         "version": "v3.6",
         "romtype": "Official"

--- a/x2/vanilla.json
+++ b/x2/vanilla.json
@@ -4,7 +4,7 @@
         "filename": "LegionOS-v3.6-x2-20210213-0850-OFFICIAL-VANILLA.zip",
         "url": "https://sourceforge.net/projects/legionrom/files/lemax2/LegionOS-v3.6-x2-20210213-0850-OFFICIAL-VANILLA.zip/download",
         "timestamp": 1613198911,
-        "md5sum": "56ddb20521edfe1054ebf1c570b8f48f",
+        "md5sum": "cef437d5d60357a49e657b34fecdfffc",
         "size": 767752554,
         "version": "v3.6",
         "romtype": "Official"


### PR DESCRIPTION
Force change md5 for both builds Vanilla and GAPPS according SF ones.